### PR TITLE
Support transform for field assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Never be afraid of javascript interop again! ^^
 
 `fence.core/+++` transforms all interop forms found in its body code
 into `fence.core/dot` and `fence.core/..` macros (`fence` version of `.` and
-`..`) which in turn will expand to `aget` forms.
+`..`) which in turn will expand to `aget` forms (or `aset` in the context of field assignment).
 
 Clojurescript forms   | Output javascript         | Optimized in :advanced mode without extern     | Optimized with extern
 ----------------------|---------------------------|------------------------------------------------|-------------------

--- a/test/fence/core_test.clj
+++ b/test/fence/core_test.clj
@@ -15,4 +15,16 @@
 
        '(.-bar foo)  '(fence.core/dot foo -bar)
        '(.bar foo baz boo)  '(fence.core/dot foo bar baz boo)
+
+       '(set! (.-bar foo) baz) '(fence.core/set! (.-bar foo) baz)
+
        :not-a-list :not-a-list))
+
+(deftest set!-test
+  (are [x y] (= (macroexpand x) y)
+       '(fence.core/set! (.-bar foo) nil) '(clojure.core/aset foo "bar" nil)
+
+       '(fence.core/set! (.. foo -bar -baz) nil)
+       '(clojure.core/aset (fence.core/dot foo -bar) "baz" nil)
+
+       '(fence.core/set! (f foo) nil) '(set! (f foo) nil)))

--- a/test/fence/core_test.clj
+++ b/test/fence/core_test.clj
@@ -16,7 +16,7 @@
        '(.-bar foo)  '(fence.core/dot foo -bar)
        '(.bar foo baz boo)  '(fence.core/dot foo bar baz boo)
 
-       '(set! (.-bar foo) baz) '(fence.core/set! (.-bar foo) baz)
+       '(set! (.-bar foo) baz) '(clojure.core/aset foo "bar" baz)
 
        :not-a-list :not-a-list))
 


### PR DESCRIPTION
With the current implementation of `+++`, the result of macro expansion for field assignments looks somewhat problematic:

```clj
cljs.user=> (def obj #js{:x 0})
#'cljs.user/obj
cljs.user=> (+++ (set! (.-x obj) 42))
clojure.lang.ExceptionInfo: set! target must be a field or a symbol naming a var
 at line 1 <cljs repl> {:file "<cljs repl>", :line 1, :column 1, :root-source-in
fo {:source-type :fragment, :source-form (+++ (set! (.-x obj) 42))}, :tag :cljs/
analysis-error}
        at clojure.core$ex_info.invokeStatic(core.clj:4617)
        at clojure.core$ex_info.invoke(core.clj:4617)
        at cljs.analyzer$error.invokeStatic(analyzer.cljc:632)
...
cljs.user=> (macroexpand '(+++ (set! (.-x obj) 42)))
(do (set! (fence.core/dot obj -x) 42))
cljs.user=>
```

(The form `(set! (fence.core/dot obj -x) 42)` will in turn be expanded to `(set! (aget obj "x") 42)`, which is a bad form.)

This PR enables `+++` macro to deal with field assignment forms appropriately.

```clj
cljs.user=> (+++ (set! (.-x obj) 42))
42
cljs.user=> (macroexpand '(+++ (set! (.-x obj) 42)))
(do (clojure.core/aset obj "x" 42))
cljs.user=>
```

Also, a new macro `fence.core/set!` is provided as a shorthand for the combination of `+++` and `set!`:

```clj
cljs.user=> (fence/set! (.-x obj) 42)
42
cljs.user=> (macroexpand-1 '(fence/set! (.-x obj) 42))
(clojure.core/aset obj "x" 42)
cljs.user=>
```